### PR TITLE
Client: when we have binary input and we refresh token, reset the input stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Here's how to package, test, and ship a new release.
 
 * Fix websocket subscription server hang with blocking server XRPC methods due to exhausting worker thread pool ([#8](https://github.com/snarfed/lexrpc/issues/8)).
 * Add `truncate` kwarg to `Client` and `Server` constructors to automatically truncate (ellipsize) string values that are longer than their ``maxGraphemes`` or ``maxLength`` in their lexicon. Defaults to `False`.
+* `Client`:
+  * Bug fix: when input is a binary stream and we refresh the token, reset the input stream so it still works for the retry of the original call.
 
 ### 0.6 - 2024-03-16
 

--- a/lexrpc/client.py
+++ b/lexrpc/client.py
@@ -5,7 +5,7 @@ TODO:
 * asyncio support for subscription websockets
 """
 import copy
-from io import BytesIO
+from io import BufferedRandom, BytesIO
 import json
 import logging
 from urllib.parse import urljoin
@@ -179,6 +179,10 @@ class Client(Base):
         # query or procedure
         fn = requests.get if type == 'query' else requests.post
         logger.debug(f'Running requests.{fn} {url} {loggable(input)} {params_str} {log_headers}')
+
+        if input and not isinstance(input, (dict, str, bytes)):
+            input = BufferedRandom(input)
+
         resp = fn(
           url,
           json=input if input and isinstance(input, dict) else None,
@@ -208,6 +212,8 @@ class Client(Base):
         elif not resp.ok:  # token expired, try to refresh it
             if output and output.get('error') in TOKEN_ERRORS:
                 self.call(REFRESH_NSID)
+                if isinstance(input, BufferedRandom):
+                    input.seek(0)
                 return self.call(nsid, input=input, headers=req_headers, **params)  # retry
 
         resp.raise_for_status()


### PR DESCRIPTION
hopefully fixes https://github.com/snarfed/bridgy/issues/1670 , cc @joelotter